### PR TITLE
fix for pressure display errors on the dashboard

### DIFF
--- a/NiclaSenseME-dashboard/NiclaSenseME/NiclaSenseME.ino
+++ b/NiclaSenseME-dashboard/NiclaSenseME/NiclaSenseME.ino
@@ -186,7 +186,7 @@ void onTemperatureCharacteristicRead(BLEDevice central, BLECharacteristic charac
 }
 
 void onHumidityCharacteristicRead(BLEDevice central, BLECharacteristic characteristic){
-  uint8_t humidityValue = humidity.value();
+  uint8_t humidityValue = humidity.value() + 0.5f;  //since we are truncating the float type to a uint8_t, we want to round it
   humidityCharacteristic.writeValue(humidityValue);
 }
 

--- a/NiclaSenseME-dashboard/index.html
+++ b/NiclaSenseME-dashboard/index.html
@@ -317,7 +317,7 @@
     {
       uuid: '19b10000-4001-537e-4f6c-d104768a1214',
       properties: ['BLERead'],
-      structure: ['Uint8'],
+      structure: ['Float32'],
       data: { pressure: [] }
     },
     accelerometer:


### PR DESCRIPTION
fix display error for pressure sensor due to mis-matched data type, also improve the accuracy of the temperature by round it