### PR TITLE
fix for sensor value errors

### DIFF
--- a/NiclaSenseME-dashboard/NiclaSenseME/NiclaSenseME.ino
+++ b/NiclaSenseME-dashboard/NiclaSenseME/NiclaSenseME.ino
@@ -36,7 +36,7 @@ BLEUnsignedIntCharacteristic humidityCharacteristic(BLE_SENSE_UUID("3001"), BLER
 BLEFloatCharacteristic pressureCharacteristic(BLE_SENSE_UUID("4001"), BLERead);
 
 BLECharacteristic accelerometerCharacteristic(BLE_SENSE_UUID("5001"), BLERead | BLENotify, 3 * sizeof(float));  // Array of 3x 2 Bytes, XY
-BLECharacteristic gyroscopeCharacteristic(BLE_SENSE_UUID("6001"), BLERead | BLENotify, 3 * sizeof(int16_t));    // Array of 3x 2 Bytes, XYZ
+BLECharacteristic gyroscopeCharacteristic(BLE_SENSE_UUID("6001"), BLERead | BLENotify, 3 * sizeof(float));    // Array of 3x 2 Bytes, XYZ
 BLECharacteristic quaternionCharacteristic(BLE_SENSE_UUID("7001"), BLERead | BLENotify, 4 * sizeof(float));     // Array of 4x 2 Bytes, XYZW
 
 BLECharacteristic rgbLedCharacteristic(BLE_SENSE_UUID("8001"), BLERead | BLEWrite, 3 * sizeof(byte)); // Array of 3 bytes, RGB

--- a/NiclaSenseME-dashboard/NiclaSenseME/NiclaSenseME.ino
+++ b/NiclaSenseME-dashboard/NiclaSenseME/NiclaSenseME.ino
@@ -186,7 +186,7 @@ void onTemperatureCharacteristicRead(BLEDevice central, BLECharacteristic charac
 }
 
 void onHumidityCharacteristicRead(BLEDevice central, BLECharacteristic characteristic){
-  uint8_t humidityValue = humidity.value();
+  uint8_t humidityValue = humidity.value() + 0.5f;  //since we are truncating the float type to a uint8_t, we want to round it
   humidityCharacteristic.writeValue(humidityValue);
 }
 

--- a/NiclaSenseME-dashboard/index.html
+++ b/NiclaSenseME-dashboard/index.html
@@ -317,7 +317,7 @@
     {
       uuid: '19b10000-4001-537e-4f6c-d104768a1214',
       properties: ['BLERead'],
-      structure: ['Uint8'],
+      structure: ['Float32'],
       data: { pressure: [] }
     },
     accelerometer:

--- a/NiclaSenseME-dashboard/index.html
+++ b/NiclaSenseME-dashboard/index.html
@@ -331,7 +331,7 @@
     {
       uuid: '19b10000-6001-537e-4f6c-d104768a1214',
       properties: ['BLENotify'],
-      structure: ['Int16', 'Int16', 'Int16'],
+      structure: ['Float32', 'Float32', 'Float32'],
       data: { 'x': [], 'y': [], 'z': [] }
     },
     led: {

--- a/NiclaSenseME-dashboard/index.html
+++ b/NiclaSenseME-dashboard/index.html
@@ -368,7 +368,7 @@
     {
       uuid: '19b10000-9003-537e-4f6c-d104768a1214',
       properties: ['BLERead'],
-      structure: ['Uint8'],
+      structure: ['Uint32'],
       data: { 'gas': [] }
     }
   }


### PR DESCRIPTION
fix sensor value errors displayed on the dashboard due to type mismatch
 - gas: both device side and web side are forced to use uint32
 - barometer: both device side and web side are forced to use float32
 - gyroscope: both device side and web side are forced to use float32
